### PR TITLE
changes to fix the db connection

### DIFF
--- a/mysql-deployment.yaml
+++ b/mysql-deployment.yaml
@@ -34,10 +34,19 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mariadb
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        - name: MYSQL_DATABASE
+          value: wordpress
+        - name: MYSQL_USER
+          value: wordpress
+        - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
               name: mysql-pass

--- a/wordpress-deployment.yaml
+++ b/wordpress-deployment.yaml
@@ -35,11 +35,15 @@ spec:
         tier: frontend
     spec:
       containers:
-      - image: wordpress:4.8-apache
+      - image: wordpress
         name: wordpress
         env:
         - name: WORDPRESS_DB_HOST
           value: wordpress-mysql
+        - name: WORDPRESS_DEBUG
+          value: "1"
+        - name: WORDPRESS_DB_USER
+          value: wordpress
         - name: WORDPRESS_DB_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Few changes to make it work:
1. used mariadb image because it has arm64 images. Used the `latest` tag
2. during creation of the database pod you can ask it to create a db, a user and a password for that user and that was needed for wordpress
3. wordpress removed the `4.8-apache` tag but you can put it back (just used latest)
4. add reference to the DB user
5. I added debug to the wordpress but you can remove it